### PR TITLE
Network name to_lowercase for verification

### DIFF
--- a/cli/src/verifier/qr.rs
+++ b/cli/src/verifier/qr.rs
@@ -71,7 +71,7 @@ fn verify_signature(verifier: &Verifier, public_key: &str) -> Result<()> {
 
 fn verify_filename(meta_values: &MetaValues, actual_qr_name: &QrFileName) -> Result<()> {
     let expected = QrFileName::new(
-        &meta_values.name,
+        &meta_values.name.to_lowercase(),
         ContentType::Metadata(meta_values.version),
         true,
     );


### PR DESCRIPTION
Use `to_lowercase` for the network `name` for the verification process. 
When the metadata file name composed the `to_lowercase` is used. For the verification `to_lowercase` should be used in order to avoid errors.
Error example is [here](https://github.com/nova-wallet/metadata-portal/runs/7310432432?check_suite_focus=true)