### PR TITLE
fix #293 support a list of rpc_endpoint for collecting the metadata

### DIFF
--- a/cli/src/collector/export.rs
+++ b/cli/src/collector/export.rs
@@ -40,7 +40,7 @@ pub(crate) fn export_specs(config: &AppConfig, fetcher: impl Fetcher) -> Result<
             ExportChainSpec {
                 title: chain.title.as_ref().unwrap_or(&chain.name).clone(),
                 color: chain.color.clone(),
-                rpc_endpoint: chain.rpc_endpoint.clone(),
+                rpc_endpoint: chain.rpc_endpoints[0].clone(), // keep only the first one
                 genesis_hash: format!("0x{}", hex::encode(&specs.genesis_hash)),
                 unit: specs.unit,
                 logo: specs.logo,

--- a/cli/src/collector/for_tests/expected.json
+++ b/cli/src/collector/for_tests/expected.json
@@ -14,7 +14,6 @@
       "signedBy": "Test Verifier",
       "source": {
         "type": "Rpc",
-        "url": "wss://rpc.polkadot.io",
         "block": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
     },

--- a/cli/src/fetch.rs
+++ b/cli/src/fetch.rs
@@ -1,8 +1,10 @@
 use anyhow::{bail, Result};
 use definitions::crypto::Encryption;
+use definitions::error_active::ErrorActive;
 use definitions::network_specs::NetworkSpecsToSend;
 use generate_message::helpers::{meta_fetch, specs_agnostic, MetaFetched};
 use generate_message::parser::Token;
+use log::warn;
 
 use crate::config::Chain;
 
@@ -11,22 +13,35 @@ pub(crate) trait Fetcher {
     fn fetch_metadata(&self, chain: &Chain) -> Result<MetaFetched>;
 }
 
+// try to call all urls unless successful
+fn call_urls<F, T>(urls: &Vec<String>, f: F) -> Result<T, ErrorActive>
+where
+    F: Fn(&str) -> Result<T, ErrorActive>,
+{
+    let n = urls.len();
+    for url in urls.iter().take(n - 1) {
+        match f(url) {
+            Ok(res) => return Ok(res),
+            Err(ErrorActive::Fetch(e)) => warn!("Failed to fetch {}: {:?}", url, e),
+            Err(e) => return Err(e),
+        }
+    }
+    f(&urls[n - 1])
+}
+
 pub(crate) struct RpcFetcher;
 
 impl Fetcher for RpcFetcher {
     fn fetch_specs(&self, chain: &Chain) -> Result<NetworkSpecsToSend> {
-        let optional_token_override = chain.token_decimals.zip(chain.token_unit.as_ref()).map(
-            |(token_decimals, token_unit)| Token {
-                decimals: token_decimals,
-                unit: token_unit.to_string(),
-            },
-        );
-        let specs = specs_agnostic(
-            &chain.rpc_endpoint,
-            Encryption::Sr25519,
-            optional_token_override,
-            None,
-        )
+        let specs = call_urls(&chain.rpc_endpoints, |url| {
+            let optional_token_override = chain.token_decimals.zip(chain.token_unit.as_ref()).map(
+                |(token_decimals, token_unit)| Token {
+                    decimals: token_decimals,
+                    unit: token_unit.to_string(),
+                },
+            );
+            specs_agnostic(url, Encryption::Sr25519, optional_token_override, None)
+        })
         .map_err(anyhow::Error::msg)?;
         if specs.name.to_lowercase() != chain.name {
             bail!(
@@ -39,7 +54,7 @@ impl Fetcher for RpcFetcher {
     }
 
     fn fetch_metadata(&self, chain: &Chain) -> Result<MetaFetched> {
-        let meta = meta_fetch(&chain.rpc_endpoint).map_err(anyhow::Error::msg)?;
+        let meta = call_urls(&chain.rpc_endpoints, meta_fetch).map_err(anyhow::Error::msg)?;
         if meta.meta_values.name.to_lowercase() != chain.name {
             bail!(
                 "Network name mismatch. Expected {}, got {}. Please fix it in `config.toml`",

--- a/cli/src/source.rs
+++ b/cli/src/source.rs
@@ -14,7 +14,7 @@ const SOURCE: &str = "Source";
 #[serde(tag = "type")]
 pub(crate) enum Source {
     Wasm { github_repo: String, hash: String },
-    Rpc { url: String, block: H256 },
+    Rpc { block: H256 },
 }
 
 // Add `Source` info to png file as a zTXt chunk
@@ -84,7 +84,6 @@ mod tests {
         fs::copy(original_png, test_png).unwrap();
 
         let source = Source::Rpc {
-            url: "wss://example.com".to_string(),
             block: H256::default(),
         };
         save_source_info(test_png, &source).unwrap();

--- a/cli/src/updater/mod.rs
+++ b/cli/src/updater/mod.rs
@@ -45,7 +45,6 @@ pub(crate) fn update_from_node(config: AppConfig, fetcher: impl Fetcher) -> anyh
             &config.qr_dir,
         )?;
         let source = Source::Rpc {
-            url: chain.rpc_endpoint,
             block: fetched_meta.block_hash,
         };
         save_source_info(&path, &source)?;

--- a/src/scheme.ts
+++ b/src/scheme.ts
@@ -33,7 +33,6 @@ export interface WasmSource extends SourceBase {
 }
 
 export interface RpcSource extends SourceBase {
-  url: string;
   block: string;
 }
 


### PR DESCRIPTION
Make 2 available option: 
**rpc_endpoint** is a string
```
[[chains]]
rpc_endpoint = "wss://rpc.polkadot.io"
```
OR 
**rpc_endpoints** is a list of strings
```
[[chains]]
rpc_endpoints = ["wss://rpc.polkadot.io"]
```