### PR TITLE
Fix dead link to Parity Signer by valid links to Novasama Polkadot Vault

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,7 +1,7 @@
 import iconSrc from "../assets/icons/vault.svg";
 import { useEffect, useState } from "react";
 
-const LINK = "https://www.parity.io/technologies/signer/";
+const LINK = "https://vault.novasama.io/";
 
 const HIDE_BANNER_KEY = "hideBanner";
 

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -38,7 +38,7 @@ export const Network = ({
 
   const vaultLink = (
     <a
-      href="https://parity.io/signer/"
+      href="https://vault.novasama.io/"
       className="font-bold"
       target="_blank"
       rel="noreferrer"


### PR DESCRIPTION
Existing links point to this dead page

![image](https://github.com/paritytech/metadata-portal/assets/513471/86970e9d-1d18-4a28-931a-47eca2dd91fb)
