### PR TITLE
eslint: detect react version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,4 +20,9 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["react", "@typescript-eslint"],
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
 };


### PR DESCRIPTION
Without this detection, the lint CI will display the following spurious warning:
```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```