### PR TITLE
use the frame size for the gray image buf

### DIFF
--- a/cli/src/common/camera.rs
+++ b/cli/src/common/camera.rs
@@ -10,10 +10,6 @@ use opencv::{
 };
 use qr_reader_phone::process_payload::{process_decoded_payload, InProgress, Ready};
 
-// Default camera settings
-const DEFAULT_WIDTH: u32 = 640;
-const DEFAULT_HEIGHT: u32 = 480;
-
 pub(crate) fn read_qr_file(source_file: &Path) -> anyhow::Result<String> {
     let mut camera = create_camera(source_file)?;
 
@@ -67,7 +63,8 @@ fn camera_capture(camera: &mut videoio::VideoCapture) -> anyhow::Result<GrayImag
         Err(e) => bail!("Can`t read camera. {}", e),
     };
 
-    let mut image: GrayImage = ImageBuffer::new(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    let mut image: GrayImage =
+        ImageBuffer::new(frame.size()?.width as u32, frame.size()?.height as u32);
     let mut ocv_gray_image = Mat::default();
 
     cvt_color(&frame, &mut ocv_gray_image, COLOR_BGR2GRAY, 0)?;


### PR DESCRIPTION
This PR changes the gray image buffer creation (for reading the signed-QR) to follow the camera frame sizing instead of cropping incorrectly to a default value.